### PR TITLE
fixed issue where theme 3 was missing the necessary styles for factlists

### DIFF
--- a/less/factlist.less
+++ b/less/factlist.less
@@ -215,7 +215,11 @@ canvas {
 
 
     &.poster-theme3 {
+        background: @theme3-bg-color;
+        color: @theme3-text-color;
         .logo-wrapper {
+            background: @theme3-bg-color;
+            color: @theme3-text-color;
             background-image: @theme3-logo-path;
             background-repeat: no-repeat;
             background-size: @theme3-sq-logo-width @theme3-sq-logo-height;


### PR DESCRIPTION
Noticed that when creating factlists theme3 failed to render correctly. Looks like the factlist.less file was missing some of the necessary styles for background and text colors.
