### PR TITLE
Update the electron target to 0.30.3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "clean:win": "rm \"Lunchbox Setup.exe\"",
 
   	"build": "npm run clean && npm run build:osx && npm run build:win",
-    "build:osx": "electron-packager www Lunchbox --platform=darwin --arch=x64 --version=0.30.1 --icon=www/img/icon-lunchbox.icns --overwrite --out electron",
-    "build:win": "electron-packager www Lunchbox --platform=win32 --arch=ia32 --version=0.30.1 --icon=www/img/icon-lunchbox.ico --overwrite --out electron",
+    "build:osx": "electron-packager www Lunchbox --platform=darwin --arch=x64 --version=0.30.3 --icon=www/img/icon-lunchbox.icns --overwrite --out electron",
+    "build:win": "electron-packager www Lunchbox --platform=win32 --arch=ia32 --version=0.30.3 --icon=www/img/icon-lunchbox.ico --overwrite --out electron",
 
     "pack": "npm run build && npm run pack:osx && npm run pack:win",
     "pack:osx": "electron-builder electron/Lunchbox-darwin-x64/Lunchbox.app --platform=osx --config=packager-config.json",


### PR DESCRIPTION
On my system this changes the default downloads directory from a hidden
directory in Application Support to ~/Documents.

refs #57.
